### PR TITLE
Fix Kconfig CONFIG_CFG80211 dependency

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,6 +1,6 @@
 config RTL8812AU
 	tristate "Realtek 8812A USB WiFi"
-	depends on USB
+	depends on USB && CFG80211
 	---help---
 	  Help message of RTL8812AU
 


### PR DESCRIPTION
This kernel module depends on CONFIG_CFG80211 without which build fails similarly to:

error: ‘struct net_device’ has no member named ‘ieee80211_ptr’

This was introduced in upstream from 5.19:

commit c304eddcecfe2513ff98ce3ae97d1c196d82ba08
Author: Jakub Kicinski <kuba@kernel.org>
Date:   Thu May 19 13:20:54 2022 -0700
    net: wrap the wireless pointers in struct net_device in an ifdef

Signed-off-by: Andrei Gherzan <andrei.gherzan@canonical.com>